### PR TITLE
Fix bug where sometimes the card name would overflow

### DIFF
--- a/app/components/autotextsize.tsx
+++ b/app/components/autotextsize.tsx
@@ -2,53 +2,29 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 
-export default function AutoTextSize({ text }: { text: any }) {
+export default function AutoTextSize({ text, depth=0 }: { text: any, depth:number}) {
     const text_element = useRef(null);
     const [font_size, setSize] = useState(100);
-    // const [isInitialRender, setIsInitialRender] = useState(true);
 
     var ro = new ResizeObserver(entries => {
         for (let entry of entries) {
-          const cr = entry.contentRect;
+            
 
           if (entry.target.parentNode !== null) {
-            if ((entry.target.parentNode as HTMLElement).scrollHeight > (entry.target.parentNode as HTMLElement).clientHeight)
+            let parent = entry.target.parentNode;
+            for(let i = 0; i<depth; i++){
+                console.log("here");
+                parent = parent.parentNode!;
+            }
+            console.log(parent);
+            if ((parent as HTMLElement).scrollHeight > (parent as HTMLElement).clientHeight)
             // || e.parentNode.scrollWidth > e.parentNode.clientWidth )
             {
-                console.log("heloooo");
                 setSize((v) => v - 1);
             }
         }
-      
-        //   console.log('Element:', entry.target);
-        //   console.log(`Element size: ${cr.width}px x ${cr.height}px`);
-        //   console.log(`Element padding: ${cr.top}px ; ${cr.left}px`);
-
-        //   console.log('Element:', entry.target.parentNode);
-        //   console.log(`Element size: ${entry.target.parentNode.contentRect.width}px x ${entry.target.parentNode.contentRect.height}px`);
-        // //   console.log(`Element padding: ${cr.top}px ; ${cr.left}px`);
-
         }
       });
-      
-      // Observe one or multiple elements
-      
-      
-    
-
-    // const resize = useCallback((element:HTMLElement) =>{
-    //     if (element != null && element != undefined) {
-    //         if (element.parentNode !== null) {
-    //             if ((element.parentNode as HTMLElement).scrollHeight > (element.parentNode as HTMLElement).clientHeight)
-    //             // || e.parentNode.scrollWidth > e.parentNode.clientWidth )
-    //             {
-    //                 console.log("heloooo");
-    //                 setSize((v) => - 1);
-    //             }
-    //         }
-    //     }
-    // },[])
-    // http://localhost:3000/test?cardLists=Aesi,%20Tyrant%20of%20Gyre%20Strait
 
     useEffect(() => {
             // setIsInitialRender(false);

--- a/app/components/cardFlip/cardFlip.tsx
+++ b/app/components/cardFlip/cardFlip.tsx
@@ -22,7 +22,7 @@ export default function CardFlip({ cards }: { cards: Card }) {
             faces.push(
                 <div className={index == 0 ? style.half : style.halfbottom}>
                     <div className={`${style.titleSplit} white`}>
-                        <div className={style.left}> <AutoTextSize text={face.name} /> </div>
+                        <div className={style.left}> <AutoTextSize text={face.name} depth={1} /> </div>
                         <div className={style.right}>
                         <p> {ManaParser(face.mana_cost)} </p>
                         </div>

--- a/app/components/cardNormal/cardNormal.tsx
+++ b/app/components/cardNormal/cardNormal.tsx
@@ -29,7 +29,7 @@ export default function CardNormal({ cards }: { cards: Card }) {
             <div className="card_cut">
             <div className={`playtest ${colors}`}>
                 <div className={`title white`}>
-                    <div className={`left`}> <AutoTextSize text={cards.name} /> </div>
+                    <div className={`left`}> <AutoTextSize text={cards.name} depth={1}/> </div>
                     <div className={`right`}> <p> {ManaParser(cards.mana_cost)} </p> </div>
                 </div>
                 <div className={`image white`}> </div>

--- a/app/components/cardSplit/cardSplit.tsx
+++ b/app/components/cardSplit/cardSplit.tsx
@@ -20,7 +20,7 @@ export default function CardSplit({ cards }: { cards: Card }) {
             faces.push(
                 <div className={`${style.half}`}>
                     <div className={`${style.titleSplit} white`}>
-                        <div className={style.left}> <AutoTextSize text={face.name} /> </div>
+                        <div className={style.left}> <AutoTextSize text={face.name} depth={1}/> </div>
                         <div className={style.right}>
                         <p> {ManaParser(face.mana_cost)} </p>
                         </div>


### PR DESCRIPTION
Sometimes the card name would overflow, to fix it I added a depth parameter to the autoresize component.
Now it looks at the parent size that matches the depth of the recursion.